### PR TITLE
No tidy rows

### DIFF
--- a/gce-plate-solver/plate-solver.py
+++ b/gce-plate-solver/plate-solver.py
@@ -197,7 +197,7 @@ def get_sources(point_sources, fits_fn, stamp_size=10, cursor=None):
         # Write out headers.
         csv_headers = ['picid', 'unit_id', 'camera_id', 'sequence_time', 'image_time']
         # Add column headers for flattened stamp.
-        csv_headers.extend([f'pixel_{i:02d}' for i in range(len(stamp_size**2))])
+        csv_headers.extend([f'pixel_{i:02d}' for i in range(stamp_size**2)])
         writer.writerow(csv_headers)
 
         for picid, row in point_sources.iterrows():

--- a/gce-plate-solver/plate-solver.py
+++ b/gce-plate-solver/plate-solver.py
@@ -197,7 +197,7 @@ def get_sources(point_sources, fits_fn, stamp_size=10, cursor=None):
         # Write out headers.
         csv_headers = ['picid', 'unit_id', 'camera_id', 'sequence_time', 'image_time']
         # Add column headers for flattened stamp.
-        csv.extend([f'pixel_{i:02d}' for i in range(len(stamp_size**2))])
+        csv_headers.extend([f'pixel_{i:02d}' for i in range(len(stamp_size**2))])
         writer.writerow(csv_headers)
 
         for picid, row in point_sources.iterrows():

--- a/gce-plate-solver/plate-solver.py
+++ b/gce-plate-solver/plate-solver.py
@@ -217,15 +217,17 @@ def get_sources(point_sources, fits_fn, stamp_size=10, cursor=None):
             # Explicit type casting to match bigquery table schema.
             stamp = data[target_slice].flatten().tolist()
 
-            # Write out stamp data
-            writer.writerow([
+            row_values = [
                 int(picid),
                 str(row.unit_id),
                 str(row.camera_id),
                 parse_date(row.seq_time),
                 parse_date(row.img_time),
-                stamp
-            ])
+            ]
+            row_values.extend(stamp)
+
+            # Write out stamp data
+            writer.writerow(row_values)
 
             # Metadata for the detection, with most of row dumped into jsonb `metadata`.
             source_metadata.append({


### PR DESCRIPTION
Having narrow-column format simply produces too many rows to be feasible and isn't strictly necessary.

This PR outputs CSV files in the `panotpes-detected/sources` bucket with the following structure: 

`panoptes-detected-sources/{unit_id}/{camera_id}/{sequence_time}/{image_time}.csv`.

There is one row per `PICID` per `image_time` with flattened arrays constituting most of the columns of the row.