### PR TITLE
Hourly stats

### DIFF
--- a/get-stats/README.md
+++ b/get-stats/README.md
@@ -1,0 +1,13 @@
+Get Stats
+=========
+
+This folder defines a [Google Cloud Function](https://cloud.google.com/functions/).
+
+This function will compile the `stats` collection into a csv file. This will be
+run hourly by a cron job to generate a static file.
+
+Endpoint: `/get-stats`
+
+### Deploy
+
+See [Deployment](../README.md#deploy) in main README for preferred deployment method.

--- a/get-stats/README.md
+++ b/get-stats/README.md
@@ -3,10 +3,34 @@ Get Stats
 
 This folder defines a [Google Cloud Function](https://cloud.google.com/functions/).
 
-This function will compile the `stats` collection into a csv file. This will be
-run hourly by a cron job to generate a static file.
+This function will compile the `stats` collection into a csv file. This function is
+called periodically by the cloud scheduler and should not need to be called manually.
 
 Endpoint: `/get-stats`
+
+Output: https://storage.googleapis.com/panoptes-exp.appspot.com/stats.csv
+
+Example usage (typically indexed by `Week` and `Unit`):
+
+```python
+import pandas as pd
+url = 'https://storage.googleapis.com/panoptes-exp.appspot.com/stats.csv'
+stats_df pd.read_csv(url).sort_values(by=['Week', 'Unit']).set_index(['Week'])
+
+stats_df.head()
+```
+
+
+|   Week | Unit   |   Images |   Observations |   Total Minutes |   Total Hours |   Year |
+|-------:|:-------|---------:|---------------:|----------------:|--------------:|-------:|
+|      1 | PAN001 |        0 |              0 |               0 |          0    |   2018 |
+|      1 | PAN001 |        0 |              0 |               0 |          0    |   2019 |
+|      1 | PAN001 |      226 |              4 |             452 |          7.53 |   2017 |
+|      1 | PAN001 |     2290 |             37 |            2290 |         38.17 |   2020 |
+|      1 | PAN008 |        0 |              0 |               0 |          0    |   2019 |
+
+
+
 
 ### Deploy
 

--- a/get-stats/deploy.sh
+++ b/get-stats/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+TOPIC=${1:-get-stats}
+
+gcloud functions deploy \
+                 "${TOPIC}" \
+                 --entry-point entry_point \
+                 --runtime python37 \
+                 --no-allow-unauthenticated \
+                 --service-account "piaa-pipeline@panoptes-exp.iam.gserviceaccount.com" \
+                 --update-labels "use=pipeline" \
+                 --trigger-http

--- a/get-stats/main.py
+++ b/get-stats/main.py
@@ -1,0 +1,79 @@
+import os
+import tempfile
+
+import pandas as pd
+from astropy import units as u
+from flask import jsonify
+from google.cloud import firestore
+from google.cloud import storage
+
+PROJECT_ID = os.getenv('PROJECT_ID', 'panoptes-exp')
+BUCKET_NAME = os.getenv('BUCKET_NAME', 'panoptes-exp.appspot.com')
+
+storage_client = storage.Client()
+output_bucket = storage_client.bucket(BUCKET_NAME)
+firestore_db = firestore.Client()
+
+
+# Entry point
+def entry_point(request):
+    # Get a real time column
+    stats_rows = [d.to_dict()
+                  for d
+                  in firestore_db.collection('stats').stream()]
+    stats_df = pd.DataFrame(stats_rows)
+
+    hours = (stats_df.total_minutes_exptime * u.minute).values.to(u.hour).value
+
+    stats_df['total_hours_exptime'] = [round(x, 2)
+                                       for x
+                                       in hours]
+    stats_df.index = pd.to_datetime(
+        stats_df.year.astype(str) + stats_df.week.map(lambda x: f'{x:02d}') + ' SUN',
+        format='%Y%W %a'
+    )
+
+    columns = {
+        'unit_id': 'Unit',
+        'week': 'Week',
+        'year': 'Year',
+        'num_images': 'Images',
+        'num_observations': 'Observations',
+        'total_minutes_exptime': 'Total Minutes',
+        'total_hours_exptime': 'Total Hours'
+    }
+
+    # Reorder
+    stats_df = stats_df.reindex(columns=list(columns.keys()))
+
+    stats_df.sort_index(inplace=True)
+    stats_df.drop(columns=['week', 'year'], inplace=True)
+
+    def reindex_by_date(group):
+        dates = pd.date_range(group.index.min(), group.index.max(), freq='W')
+        unit_id = group.iloc[0].unit_id
+        group = group.reindex(dates).fillna(0)
+        group.unit_id = unit_id
+
+        return group
+
+    stats_df = stats_df.groupby(['unit_id']).apply(reindex_by_date).droplevel(0)
+
+    stats_df['year'] = stats_df.index.year
+    stats_df['week'] = stats_df.index.week
+
+    stats_df = stats_df.rename(columns=columns)
+    stats_df = stats_df.reset_index(drop=True).set_index(['Week'])
+
+    stats_df = stats_df.sort_index()
+
+    # Write out temporary csv.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        csv_path = os.path.join(tmp_dir, 'stats.csv')
+        stats_df.reset_index().to_csv(csv_path, index=False)
+
+        blob = output_bucket.blob('stats.csv')
+        blob.upload_from_filename(csv_path)
+        blob.make_public()
+
+    return jsonify(success=True, public_url=blob.public_url)

--- a/get-stats/requirements.txt
+++ b/get-stats/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+astropy
+google-cloud-firestore
+google-cloud-storage
+pandas

--- a/plate-solver/solver.py
+++ b/plate-solver/solver.py
@@ -226,8 +226,10 @@ def solve_file(bucket_path, solve_config=None, background_config=None):
         # Remove the original fpacked file
         if solved_path == local_path:
             print(f'Removing the existing fpacked file before packing new')
-            with suppress(FileNotFoundError):
+            try:
                 os.remove(local_path)
+            except Exception as e:
+                print(f'Error removing existing fpacked: {e!r}')
         solved_path = fits_utils.fpack(solved_path)
 
         #  Upload the plate-solved image.


### PR DESCRIPTION
A service to save the panoptes stats to a csv file. This will be called by a cloud cron job every hour.  The Data Explorer can use this file directly rather than doing a firestore lookup. It can also be used by anyone in any context for an easier way to get stats without the firestore authentication.