### PR TITLE
Fix most recent data for data explorer

### DIFF
--- a/data-explorer/cloudbuild.yaml
+++ b/data-explorer/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 # Build
-- name: 'docker'
+- name: 'gcr.io/cloud-builders/docker'
   id: 'base'
   args:
   - 'build'
@@ -10,7 +10,7 @@ steps:
   waitFor: ['-']
 
 # Push
-- name: 'docker'
+- name: 'gcr.io/cloud-builders/docker'
   id: 'push-base'
   args:
   - 'push'

--- a/data-explorer/modules/observations.py
+++ b/data-explorer/modules/observations.py
@@ -19,8 +19,6 @@ PROJECT_ID = os.getenv('PROJECT_ID', 'panoptes-exp')
 BASE_URL = os.getenv('BASE_URL', 'https://storage.googleapis.com/panoptes-exp.appspot.com/observations.csv')
 OBSERVATIONS_BASE_URL = os.getenv('OBSERVATIONS_BASE_URL', 'https://storage.googleapis.com/panoptes-observations')
 
-now = pendulum.now().replace(tzinfo=None)
-
 
 class ObservationsExplorer(param.Parameterized):
     """Param interface for inspecting observations"""
@@ -55,8 +53,8 @@ class ObservationsExplorer(param.Parameterized):
     )
     time = param.DateRange(
         label='Date Range',
-        default=(pendulum.parse('2016-01-01').replace(tzinfo=None), now),
-        bounds=(pendulum.parse('2016-01-01').replace(tzinfo=None), now)
+        default=(pendulum.parse('2016-01-01').replace(tzinfo=None), pendulum.now().replace(tzinfo=None)),
+        bounds=(pendulum.parse('2016-01-01').replace(tzinfo=None), pendulum.now().replace(tzinfo=None))
     )
     min_num_images = param.Integer(
         doc='Minimum number of images.',
@@ -94,6 +92,7 @@ class ObservationsExplorer(param.Parameterized):
     def update_dataset(self):
         if self.show_recent:
             # Get just the recent result on initial load
+            now = pendulum.now().replace(tzinfo=None)
             df = search_observations(ra=180,
                                      dec=0,
                                      radius=180,


### PR DESCRIPTION
* Fixing when the `now` variable is declared.
* Using cloudbuilders because of version mismatch with docker 1.39 and 1.40